### PR TITLE
Use the default node.js query string library

### DIFF
--- a/lib/cheddargetter.js
+++ b/lib/cheddargetter.js
@@ -1,158 +1,158 @@
 var https = require("https");
-var qs = require("qs");
+var qs = require("querystring");
 var xml2js = require("xml2js");
 
 var cheddargetter = module.exports = function (user, pass, productCode) {
-	this.auth = "Basic " + new Buffer(user + ":" + pass).toString("base64");
-	this.pass = pass;
-	this.productCode = productCode;
+  this.auth = "Basic " + new Buffer(user + ":" + pass).toString("base64");
+  this.pass = pass;
+  this.productCode = productCode;
 };
 
 cheddargetter.prototype.callAPI = function (data, path, callback) {
-	if (typeof(path) == "function") {
-		callback = path;
-		path = data;
-		data = null;
-	}
+  if (typeof(path) == "function") {
+    callback = path;
+    path = data;
+    data = null;
+  }
 
-	var config = {
-		host: "cheddargetter.com",
-		port: 443,
-		headers: {authorization: this.auth},
-		path: "/xml" + path,
-		method: "POST"
-	};
+  var config = {
+    host: "cheddargetter.com",
+    port: 443,
+    headers: {authorization: this.auth},
+    path: "/xml" + path,
+    method: "POST"
+  };
 
-	if (data) {
-		data = qs.stringify(data);
+  if (data) {
+    data = qs.stringify(data);
 
-		config.headers["Content-Type"] = "application/x-www-form-urlencoded";
-		config.headers["Content-Length"] = data.length;
-	}
+    config.headers["Content-Type"] = "application/x-www-form-urlencoded";
+    config.headers["Content-Length"] = data.length;
+  }
 
-	var req = https.request(config, function (res) {
-		var data = "";
+  var req = https.request(config, function (res) {
+    var data = "";
 
-		res.on("data", function (chunk) {
-			data += chunk;
-		});
+    res.on("data", function (chunk) {
+      data += chunk;
+    });
 
-		res.on("end", function () {
-			var xml = new xml2js.Parser();
-			xml.parseString(data, function (err, xml) {
-				var type = Object.keys(xml)[0];
+    res.on("end", function () {
+      var xml = new xml2js.Parser();
+      xml.parseString(data, function (err, xml) {
+        var type = Object.keys(xml)[0];
 
-				if (type == "#") {
-					callback(new Error(xml["#"]));
-				} else {
-					callback(null, xml[type]);
-				}
-			});
-		});
-	});
+        if (type == "#") {
+          callback(new Error(xml["#"]));
+        } else {
+          callback(null, xml[type]);
+        }
+      });
+    });
+  });
 
-	req.on("error", function (err) {
-		console.log("Payment API Error");
-		callback(err, null);
-	});
+  req.on("error", function (err) {
+    console.log("Payment API Error");
+    callback(err, null);
+  });
 
-	if (data) {
-		req.write(data);
-	}
+  if (data) {
+    req.write(data);
+  }
 
-	req.end();
+  req.end();
 };
 
 cheddargetter.prototype.getAllPricingPlans = function (callback) {
-	this.callAPI("/plans/get/productCode/" + this.productCode, callback);
+  this.callAPI("/plans/get/productCode/" + this.productCode, callback);
 };
 
 cheddargetter.prototype.getPricingPlan = function (code, callback) {
-	this.callAPI("/plans/get/productCode/" + this.productCode + "/code/" + code, callback);
+  this.callAPI("/plans/get/productCode/" + this.productCode + "/code/" + code, callback);
 };
 
 cheddargetter.prototype.getAllCustomers = function (data, callback) {
-	if (!callback && typeof(data) == "function") {
-		callback = data;
-		data = null;
-	}
-	this.callAPI(data, "/customers/get/productCode/" + this.productCode, callback);
+  if (!callback && typeof(data) == "function") {
+    callback = data;
+    data = null;
+  }
+  this.callAPI(data, "/customers/get/productCode/" + this.productCode, callback);
 };
 
 cheddargetter.prototype.getCustomer = function (code, callback) {
-	this.callAPI("/customers/get/productCode/" + this.productCode + "/code/" + code, callback);
+  this.callAPI("/customers/get/productCode/" + this.productCode + "/code/" + code, callback);
 };
 
 cheddargetter.prototype.createCustomer = function (data, callback) {
-	this.callAPI(data, "/customers/new/productCode/" + this.productCode, callback);
+  this.callAPI(data, "/customers/new/productCode/" + this.productCode, callback);
 };
 
 cheddargetter.prototype.editCustomerAndSubscription = function (code, data, callback) {
-	this.callAPI(data, "/customers/edit/productCode/" + this.productCode + "/code/" + code, callback);
+  this.callAPI(data, "/customers/edit/productCode/" + this.productCode + "/code/" + code, callback);
 };
 cheddargetter.prototype.updateCustomerAndSubscription = cheddargetter.prototype.editCustomerAndSubscription;
 
 cheddargetter.prototype.editCustomer = function (code, data, callback) {
-	this.callAPI(data, "/customers/edit-customer/productCode/" + this.productCode + "/code/" + code, callback);
+  this.callAPI(data, "/customers/edit-customer/productCode/" + this.productCode + "/code/" + code, callback);
 };
 cheddargetter.prototype.updateCustomer = cheddargetter.prototype.editCustomer;
 
 cheddargetter.prototype.editSubscription = function (code, data, callback) {
-	this.callAPI(data, "/customers/edit-subscription/productCode/" + this.productCode + "/code/" + code, callback);
+  this.callAPI(data, "/customers/edit-subscription/productCode/" + this.productCode + "/code/" + code, callback);
 };
 cheddargetter.prototype.updateSubscription = cheddargetter.prototype.editSubscription;
 
 cheddargetter.prototype.deleteCustomer = function (customerCode, callback) {
-	this.callAPI("/customers/delete/productCode/" + this.productCode + "/code/" + customerCode, callback);
+  this.callAPI("/customers/delete/productCode/" + this.productCode + "/code/" + customerCode, callback);
 };
 
 cheddargetter.prototype.cancelSubscription = function (customerCode, callback) {
-	this.callAPI("/customers/cancel/productCode/" + this.productCode + "/code/" + customerCode, callback);
+  this.callAPI("/customers/cancel/productCode/" + this.productCode + "/code/" + customerCode, callback);
 };
 
 cheddargetter.prototype.addItem = function (customerCode, itemCode, amount, callback) {
-	if (!callback && typeof(amount) == "function") {
-		callback = amount;
-		amount = null;
-	}
+  if (!callback && typeof(amount) == "function") {
+    callback = amount;
+    amount = null;
+  }
 
-	if (amount) {
-		amount = {quantity: amount.toString()};
-	}
+  if (amount) {
+    amount = {quantity: amount.toString()};
+  }
 
-	this.callAPI(amount, "/customers/add-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
+  this.callAPI(amount, "/customers/add-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
 };
 
 cheddargetter.prototype.removeItem = function (customerCode, itemCode, amount, callback) {
-	if (!callback && typeof(amount) == "function") {
-		callback = amount;
-		amount = null;
-	}
+  if (!callback && typeof(amount) == "function") {
+    callback = amount;
+    amount = null;
+  }
 
-	if (amount) {
-		amount = {quantity: amount.toString()};
-	}
+  if (amount) {
+    amount = {quantity: amount.toString()};
+  }
 
-	this.callAPI(amount, "/customers/remove-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
+  this.callAPI(amount, "/customers/remove-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
 };
 
 cheddargetter.prototype.setItemQuantity = function (customerCode, itemCode, amount, callback) {
-	amount = {quantity: amount.toString()};
-	this.callAPI(amount, "/customers/set-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
+  amount = {quantity: amount.toString()};
+  this.callAPI(amount, "/customers/set-item-quantity/productCode/" + this.productCode + "/code/" + customerCode + "/itemCode/" + itemCode, callback);
 };
 
 cheddargetter.prototype.addCustomCharge = function (customerCode, chargeCode, quantity, amount, description, callback) {
-	var data = {
-		chargeCode: chargeCode,
-		quantity: quantity.toString(),
-		eachAmount: amount.toString(),
-		description: description
-	};
+  var data = {
+    chargeCode: chargeCode,
+    quantity: quantity.toString(),
+    eachAmount: amount.toString(),
+    description: description
+  };
 
-	this.callAPI(data, "/customers/add-charge/productCode/" + this.productCode + "/code/" + customerCode, callback);
+  this.callAPI(data, "/customers/add-charge/productCode/" + this.productCode + "/code/" + customerCode, callback);
 };
 
 cheddargetter.prototype.deleteCustomCharge = function (customerCode, chargeId, callback) {
-	chargeId = {chargeId: chargeId};
-	this.callAPI(amount, "/customers/delete-charge/productCode/" + this.productCode + "/code/" + customerCode, callback);
+  chargeId = {chargeId: chargeId};
+  this.callAPI(amount, "/customers/delete-charge/productCode/" + this.productCode + "/code/" + customerCode, callback);
 };

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
 	"homepage": "https://github.com/respectTheCode/node-cheddargetter",
 	"dependencies": {
 		"async": "0.1.x",
-		"xml2js": "0.1.x",
-		"qs": "0.3.x"
+		"xml2js": "0.1.x"
 	},
 	"devDependencies": {
 		"nodeunit": "0.6.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cheddargetter",
-	"version": "0.1.4-1",
+	"version": "0.1.5",
 	"author": "Kevin Smith",
 	"repository": {
 		"type": "git",

--- a/test/cheddargetter.js
+++ b/test/cheddargetter.js
@@ -5,157 +5,157 @@ var CheddarGetter = require("../lib/cheddargetter");
 var config = {};
 
 try {
-	var json = fs.readFileSync("./config.conf").toString();
-	json = JSON.parse(json);
+  var json = fs.readFileSync("./config.conf").toString();
+  json = JSON.parse(json);
 
-	for (var key in json) {
-		if (json.hasOwnProperty(key)) {
-			config[key] = json[key];
-		}
-	}
+  for (var key in json) {
+    if (json.hasOwnProperty(key)) {
+      config[key] = json[key];
+    }
+  }
 } catch (error) {
-	console.log("Error: " + error);
-	process.exit();
+  console.log("Error: " + error);
+  process.exit();
 }
 
 module.exports = {};
 
 module.exports.Plans = function (test) {
-	var cg = new CheddarGetter(config.user, config.pass, config.productCode);
-	async.waterfall([function (cb) {
-		cg.getAllPricingPlans(cb);
-	}, function (result, cb) {
-		test.equal(typeof(result),"object", "getAllPricingPlans should return a plan array");
-		test.ok(result.length > 0, "There should be more than 0 plans");
+  var cg = new CheddarGetter(config.user, config.pass, config.productCode);
+  async.waterfall([function (cb) {
+    cg.getAllPricingPlans(cb);
+  }, function (result, cb) {
+    test.equal(typeof(result),"object", "getAllPricingPlans should return a plan array");
+    test.ok(result.length > 0, "There should be more than 0 plans");
 
-		cg.getPricingPlan(result[0]["@"].code, cb);
-	}, function (result, cb) {
-		test.equal(typeof(result), "object", "getPricingPlan should return a plan object");
+    cg.getPricingPlan(result[0]["@"].code, cb);
+  }, function (result, cb) {
+    test.equal(typeof(result), "object", "getPricingPlan should return a plan object");
 
-		cb();
-	}], function (err) {
-		test.ifError(err);
-		test.done();
-	});
+    cb();
+  }], function (err) {
+    test.ifError(err);
+    test.done();
+  });
 };
 
 module.exports.PlanError = function (test) {
-	var cg = new CheddarGetter(config.user, config.pass, config.productCode);
+  var cg = new CheddarGetter(config.user, config.pass, config.productCode);
 
-	cg.getPricingPlan("Bad Plan Code", function (err, customer) {
-		test.notEqual(err, null);
-		test.equal(customer, null);
-		test.done();
-	});
+  cg.getPricingPlan("Bad Plan Code", function (err, customer) {
+    test.notEqual(err, null);
+    test.equal(customer, null);
+    test.done();
+  });
 };
 
 module.exports.Customers = function (test) {
-	var cg = new CheddarGetter(config.user, config.pass, config.productCode);
-	async.waterfall([function (cb) {
-		cg.createCustomer({
-			code: "test",
-			firstName: "FName",
-			lastName: "LName",
-			email: "test@test.com",
-			subscription: {
-				planCode: config.planCode,
-				method: "cc",
-				ccNumber: "4111111111111111",
-				ccExpiration: "12/2012",
-				ccCardCode: "123",
-				ccFirstName: "FName",
-				ccLastName:"LName",
-				ccZip: "95123"
-			}
-		}, cb);
-	}, function (result, cb) {
-		cg.createCustomer({
-			code: "test1",
-			firstName: "FName2",
-			lastName: "LName2",
-			email: "test2@test.com",
-			subscription: {
-				planCode: config.planCode,
-				method: "cc",
-				ccNumber: "4111111111111111",
-				ccExpiration: "12/2012",
-				ccCardCode: "123",
-				ccFirstName: "FName2",
-				ccLastName:"LName2",
-				ccZip: "95123"
-			}
-		}, cb);
-	}, function (result, cb) {
-		cg.getAllCustomers(cb);
-	}, function (result, cb) {
-		test.equal(typeof(result), "object", "getAllCustomers should return a customer array");
-		test.equal(result.length, 2, "getAllCustomers should return 2 customers");
-		test.equal(result[0]["@"].code, "test", "first customer should be 'test'");
+  var cg = new CheddarGetter(config.user, config.pass, config.productCode);
+  async.waterfall([function (cb) {
+    cg.createCustomer({
+      code: "test",
+      firstName: "FName",
+      lastName: "LName",
+      email: "test@test.com",
+      subscription: {
+        planCode: config.planCode,
+        method: "cc",
+        ccNumber: "4111111111111111",
+        ccExpiration: "12/2012",
+        ccCardCode: "123",
+        ccFirstName: "FName",
+        ccLastName:"LName",
+        ccZip: "95123"
+      }
+    }, cb);
+  }, function (result, cb) {
+    cg.createCustomer({
+      code: "test1",
+      firstName: "FName2",
+      lastName: "LName2",
+      email: "test2@test.com",
+      subscription: {
+        planCode: config.planCode,
+        method: "cc",
+        ccNumber: "4111111111111111",
+        ccExpiration: "12/2012",
+        ccCardCode: "123",
+        ccFirstName: "FName2",
+        ccLastName:"LName2",
+        ccZip: "95123"
+      }
+    }, cb);
+  }, function (result, cb) {
+    cg.getAllCustomers(cb);
+  }, function (result, cb) {
+    test.equal(typeof(result), "object", "getAllCustomers should return a customer array");
+    test.equal(result.length, 2, "getAllCustomers should return 2 customers");
+    test.equal(result[0]["@"].code, "test", "first customer should be 'test'");
 
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(typeof(result), "object", "getCustomer should return a customer object");
-		cb();
-	}], function (err) {
-		test.ifError(err);
-		test.done();
-	});
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(typeof(result), "object", "getCustomer should return a customer object");
+    cb();
+  }], function (err) {
+    test.ifError(err);
+    test.done();
+  });
 };
 
 module.exports.CustomerError = function (test) {
-	var cg = new CheddarGetter(config.user, config.pass, config.productCode);
+  var cg = new CheddarGetter(config.user, config.pass, config.productCode);
 
-	cg.getCustomer("Bad Customer Code", function (err, customer) {
-		test.notEqual(err, null);
-		test.equal(customer, null);
-		test.done();
-	});
+  cg.getCustomer("Bad Customer Code", function (err, customer) {
+    test.notEqual(err, null);
+    test.equal(customer, null);
+    test.done();
+  });
 };
 
 module.exports.Items = function (test) {
-	var cg = new CheddarGetter(config.user, config.pass, config.productCode);
+  var cg = new CheddarGetter(config.user, config.pass, config.productCode);
 
-	async.waterfall([function (cb) {
-		cg.setItemQuantity("test", config.itemCode, 5, cb);
-	}, function (result, cb) {
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5);
-		cb(null, {});
-	}, function (result, cb) {
-		cg.addItem("test", config.itemCode, 2, cb);
-	}, function (result, cb) {
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2);
-		cb(null, {});
-	}, function (result, cb) {
-		cg.addItem("test", config.itemCode, cb);
-	}, function (result, cb) {
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1);
-		cb(null, {});
-	}, function (result, cb) {
-		cg.removeItem("test", config.itemCode, 2, cb);
-	}, function (result, cb) {
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1 - 2);
-		cb(null, {});
-	}, function (result, cb) {
-		cg.removeItem("test", config.itemCode, cb);
-	}, function (result, cb) {
-		cg.getCustomer("test", cb);
-	}, function (result, cb) {
-		test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1 - 2 - 1);
-		cb(null, {});
-	}, function (result, cb) {
-		cg.deleteCustomer("test", cb);
-	}, function (result, cb) {
-		cg.deleteCustomer("test1", cb);
-	}], function (err) {
-		test.ifError(err);
-		test.done();
-	});
+  async.waterfall([function (cb) {
+    cg.setItemQuantity("test", config.itemCode, 5, cb);
+  }, function (result, cb) {
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5);
+    cb(null, {});
+  }, function (result, cb) {
+    cg.addItem("test", config.itemCode, 2, cb);
+  }, function (result, cb) {
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2);
+    cb(null, {});
+  }, function (result, cb) {
+    cg.addItem("test", config.itemCode, cb);
+  }, function (result, cb) {
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1);
+    cb(null, {});
+  }, function (result, cb) {
+    cg.removeItem("test", config.itemCode, 2, cb);
+  }, function (result, cb) {
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1 - 2);
+    cb(null, {});
+  }, function (result, cb) {
+    cg.removeItem("test", config.itemCode, cb);
+  }, function (result, cb) {
+    cg.getCustomer("test", cb);
+  }, function (result, cb) {
+    test.equal(parseInt(result.subscriptions.subscription.items.item[0].quantity, 10), 5 + 2 + 1 - 2 - 1);
+    cb(null, {});
+  }, function (result, cb) {
+    cg.deleteCustomer("test", cb);
+  }, function (result, cb) {
+    cg.deleteCustomer("test1", cb);
+  }], function (err) {
+    test.ifError(err);
+    test.done();
+  });
 };


### PR DESCRIPTION
The `qs` library which was used filtered out stuff like `isVatExempt=1`. In the query it only left `&isVatExempt`, without any value. Cheddargetter didn't understand that a customer was now vatExempt.

The only real change is:

```
-var qs = require("qs");
+var qs = require("querystring");
```
