### PR TITLE
New qs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cheddargetter",
-	"version": "0.1.4-1",
+	"version": "0.1.5",
 	"author": "Kevin Smith",
 	"repository": {
 		"type": "git",
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"async": "0.1.x",
 		"xml2js": "0.1.x",
-		"qs": "0.3.x"
+		"qs": "0.6.x"
 	},
 	"devDependencies": {
 		"nodeunit": "0.6.x"


### PR DESCRIPTION
The old `qs` version could not handle parameters like `isVatExampt=1`. It would simply stringify it to `&isVatExempt`, without any value.
